### PR TITLE
fix: compressed decoder

### DIFF
--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -47,7 +47,10 @@ module ibex_compressed_decoder (
             // c.addi4spn -> addi rd', x2, imm
             instr_o = {2'b0, instr_i[10:7], instr_i[12:11], instr_i[5],
                        instr_i[6], 2'b00, 5'h02, 3'b000, 2'b01, instr_i[4:2], {OPCODE_OP_IMM}};
-            if (instr_i[12:5] == 8'b0)  illegal_instr_o = 1'b1;
+            if (instr_i[12:5] == 8'b0) begin
+              illegal_instr_o = 1'b1;
+              instr_o = instr_i;
+            end
           end
 
           3'b010: begin


### PR DESCRIPTION
Output the original instruction for `0x0000` cases.